### PR TITLE
Fixing installation isssues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ shapely==1.7.1
 matplotlib==3.3.4
 pyod==0.8.7
 fastdtw==0.3.4
-tslearn==0.5.0.5
 h5py==3.1.0
 geoalchemy2>=0.8.4
 networkx>=2.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,13 +48,12 @@ install_requires =
     importlib-metadata; python_version<"3.8"
     pandas>=1.2.2
     scipy>=1.6.1
-    tsfresh>=0.17.0
+    tsfresh<=0.17.0
     xlrd>=2.0.1
     shapely>=1.7.1
     matplotlib>=3.3.4
     pyod>=0.8.7
     fastdtw>=0.3.4
-    tslearn>=0.5.0.5
     h5py>=3.1.0
     geoalchemy2>=0.8.4
     networkx>=2.5

--- a/src/movekit/__init__.py
+++ b/src/movekit/__init__.py
@@ -23,7 +23,7 @@ from .preprocess import preprocess, filter_dataframe, replace_parts_animal_movem
 from .feature_extraction import extract_features, euclidean_dist  # noqa: E402
 from .feature_extraction import ts_feature, ts_all_features, explore_features_geospatial, centroid_medoid_computation, \
     outlier_detection, group_movement
-from .clustering import dtw_matrix, ts_cluster, get_heading_difference, compute_polarization, get_spatial_objects, compute_centroid_direction
+from .clustering import dtw_matrix, get_heading_difference, compute_polarization, get_spatial_objects, compute_centroid_direction
 # noqa: E402
 from .plot import plot_animal, plot_pace, plot_movement  # noqa: E402
 

--- a/src/movekit/clustering.py
+++ b/src/movekit/clustering.py
@@ -8,7 +8,7 @@ from shapely.geometry import Polygon
 import matplotlib.pyplot as plt
 from fastdtw import fastdtw
 from scipy.spatial.distance import euclidean
-from tslearn.clustering import TimeSeriesKMeans
+#from tslearn.clustering import TimeSeriesKMeans
 from functools import reduce
 
 from .feature_extraction import *
@@ -71,7 +71,7 @@ def dtw_matrix(preprocessed_data, path=False, distance=euclidean):
     else:
         return distance_df
 
-
+"""
 def ts_cluster(feats,
                n_clust,
                varlst=[
@@ -82,7 +82,7 @@ def ts_cluster(feats,
                max_iter=5,
                random_state=0,
                inertia=False):
-    """
+
     Incorporate time series clustering for absolute features.
 
     Note: Function can be used with extracted features beforehand. If features are not extracted, function performs
@@ -96,7 +96,6 @@ def ts_cluster(feats,
     :param random_state: Default: 0.
     :param inertia: Additionaly return sum of distances of samples to their closest cluster center.
     :return: Default: features-dataframe with cluster and centroid columns added. Optional: inertia (see above).
-    """
 
     # check for each feature if it's contained in feats dataset - if not, calculate
     for feat in varlst:
@@ -154,7 +153,7 @@ def ts_cluster(feats,
 
     else:
         return clustered_df
-
+"""
 
 def compute_centroid_direction(data,
                                colname="centroid_direction",


### PR DESCRIPTION
Fixing installation issues

- issues with tslearn when installing mkit locally. tslearn is only used for the TimeSeriesKMeans function. I have deactivated tslearn and the respective function, since this was always quite time consuming. 
- issues with tsfresh v 0.18. Temporarily downgraded to v 0.17 in setup.cfg