### PR TITLE
openpyxl requirement, io handling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 scipy==1.6.1
 tsfresh==0.17.0
-xlrd==2.0.1
+openpyxl==3.0.7
 shapely==1.7.1
 matplotlib==3.3.4
 pyod==0.8.7

--- a/src/movekit/io.py
+++ b/src/movekit/io.py
@@ -3,7 +3,6 @@ import numpy as np
 from pandas.api.types import is_numeric_dtype, is_string_dtype
 from pandas.errors import EmptyDataError
 
-
 def parse_csv(path_to_file):
     """
     Read CSV file into Pandas DataFrame.
@@ -20,6 +19,8 @@ def parse_csv(path_to_file):
 
         # change column names all to lower case values
         data.columns = map(str.lower, data.columns)
+
+        format_col = ['time', 'animal_id', 'x', 'y']
 
         # check if all required columns are there in the right format
         if 'time' in data and 'animal_id' in data and 'x' in data and 'y' in data:
@@ -43,11 +44,13 @@ def parse_csv(path_to_file):
                 )
 
             return data
+        else:
+            raise ValueError('Movekit requires columns to be named {} but was given {} instead'.format(format_col, data.columns))
+
     except FileNotFoundError:
         print("The file could not be found.\nPath given: {0}\n\n".format(
             path_to_file))
-    except EmptyDataError:
-        print("The provided dataset is empty}\n\n".format(path_to_file))
+
 
 
 def parse_excel(path_to_file):
@@ -64,8 +67,13 @@ def parse_excel(path_to_file):
         else:
             data = pd.read_excel(path_to_file + '.xlsx')
 
+        if data.empty:
+            raise EmptyDataError
+
         # change column names all to lower case values
         data.columns = map(str.lower, data.columns)
+
+        format_col = ['time', 'animal_id', 'x', 'y']
 
         # check if all required columns are there in the right format
         if 'time' in data and 'animal_id' in data and 'x' in data and 'y' in data:
@@ -88,12 +96,12 @@ def parse_excel(path_to_file):
                     "\n'heading_angle' attribute is found and will be processed\n"
                 )
             return data
+        else:
+            raise ValueError('Movekit requires columns to be named {} but was given {} instead'.format(format_col, data.columns))
 
     except FileNotFoundError:
         print("The file could not be found.\nPath given: {0}\n\n".format(
             path_to_file))
-    except EmptyDataError:
-        print("The provided dataset is empty}\n\n".format(path_to_file))
 
 
 def read_data(path):

--- a/tests/Io.py
+++ b/tests/Io.py
@@ -1,5 +1,3 @@
-
-
 import os
 import unittest
 import pandas as pd
@@ -74,19 +72,11 @@ class Test_IO(unittest.TestCase):
 
     def test_read_csv_file_empty(self):
         path = '../tests/data/empty.csv'
-        self.assertRaises(EmptyDataError, parse_excel(path))
+        self.assertRaises(EmptyDataError, lambda: parse_csv(path))
 
     def test_read_csv_file_missing_header(self):
-        path = '../tests/data/missing-col.csv'
-
-        # df = parse_csv(path)
-        df = pd.read_csv(path)
-
-        expected = ['time', 'animal_id', 'x', 'y']
-        result = list(df.columns)
-
-        # self.assertCountEqual(result, expected)
-        self.assertNotEqual(result, expected)
+        path = '../tests/data/missing-header.csv'
+        self.assertRaises(ValueError, lambda: parse_csv(path))
 
     '''
     Unit test for Microsoft Excel file
@@ -114,17 +104,11 @@ class Test_IO(unittest.TestCase):
     def test_read_excel_file_empty(self):
         path = '../tests/data/empty.xlsx'
 
-        self.assertRaises(EmptyDataError, parse_excel(path))
+        self.assertRaises(EmptyDataError, lambda: parse_excel(path))
 
     def test_read_excel_file_missing_header(self):
-        path = '../tests/data/missing-col.xlsx'
-
-        df = pd.read_excel(path)
-        expected = ['time', 'animal_id', 'x', 'y']
-        result = list(df.columns)
-
-        # self.assertCountEqual(result, expected)
-        self.assertNotEqual(expected, result)
+        path = '../tests/data/missing-header.xlsx'
+        self.assertRaises(ValueError, lambda: parse_excel(path))
 
     def test_csv_excel_equal(self):
         '''


### PR DESCRIPTION
failed unit tests due to xlrd:
ValueError: Your version of xlrd is 2.0.1. In xlrd >= 2.0, only the xls format is supported. Install openpyxl instead.

xlrd has explicitly removed support for anything other than xls files, but we are dealing with xlsx files